### PR TITLE
fix: Android error handling, iOS memory leaks & Legacy View Manager Interop

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,9 @@ import groovy.json.JsonSlurper
 def registrationCompat = {
   def reactNativeManifest = file("$rootDir/../node_modules/react-native/package.json").exists()
     ? file("$rootDir/../node_modules/react-native/package.json")
-    : file("$rootDir/../../node_modules/react-native/package.json")
+    : file("$rootDir/../../node_modules/react-native/package.json").exists()
+      ? file("$rootDir/../../node_modules/react-native/package.json")
+      : file("$rootDir/../../../node_modules/react-native/package.json")
   def reactNativeVersion = new JsonSlurper().parseText(reactNativeManifest.text).version as String
   // Fabric was introduced at react-native@0.68, full CMake support were introduced at react-native@0.70
   // Use Android.mk for compatibility with react-native@0.68/0.69

--- a/ios/ReactNativeVideoPlayerView.h
+++ b/ios/ReactNativeVideoPlayerView.h
@@ -8,7 +8,33 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// Dummy block type for interop compatibility
+typedef void (^RCTDirectEventBlock)(NSDictionary *_Nullable body);
+
 @interface ReactNativeVideoPlayerView : RCTViewComponentView
+
+// Props for Legacy View Manager Interop compatibility
+// These are handled via updateProps in New Architecture but must be declared
+// for the interop layer which expects individual setters
+@property(nonatomic, copy, nullable) NSDictionary *source;
+@property(nonatomic, assign) BOOL paused;
+@property(nonatomic, assign) Float64 seek;
+@property(nonatomic, assign) float volume;
+@property(nonatomic, assign) float speed;
+@property(nonatomic, assign) BOOL muted;
+@property(nonatomic, assign) BOOL loop;
+@property(nonatomic, copy, nullable) NSString *resizeMode;
+@property(nonatomic, assign) int progressUpdateInterval;
+
+// Event callbacks for Legacy View Manager Interop compatibility
+// These are not used in New Architecture (event emitters are used instead)
+// but must be declared to avoid crashes when interop layer tries to set them
+@property(nonatomic, copy, nullable) RCTDirectEventBlock onReadyForDisplay;
+@property(nonatomic, copy, nullable) RCTDirectEventBlock onLoad;
+@property(nonatomic, copy, nullable) RCTDirectEventBlock onProgress;
+@property(nonatomic, copy, nullable) RCTDirectEventBlock onEnd;
+@property(nonatomic, copy, nullable) RCTDirectEventBlock onBuffer;
+@property(nonatomic, copy, nullable) RCTDirectEventBlock onError;
 
 - (void)play;
 - (void)pause;


### PR DESCRIPTION
## Summary

This PR brings several stability and compatibility improvements from production patches.

## Android Changes

### Error Handling
- Add try-catch for `setDataSource` and `prepareAsync` to prevent uncaught exceptions
- Emit proper error events (`MEDIA_ERROR_INVALID_SOURCE`, `MEDIA_ERROR_PREPARE_FAILED`) instead of crashing
- Move `onLoad` event to `onPrepared` for more consistent timing across platforms

### Build
- Fix monorepo path resolution in `build.gradle` (support 3 levels deep for nested workspaces)

## iOS Changes

### Memory Leak Fixes
- Add `_didRelease` flag to prevent double-release crashes
- Use weak references in time observer block to prevent retain cycles
- Improve observer removal with try-catch to handle already-removed observers
- Implement `dealloc` method for proper cleanup
- Fix `prepareForRecycle` to properly clear player item

### Legacy View Manager Interop
- Add compatibility props and event callbacks for bridgeless architecture with interop layer
- Support both Fabric event emitters and legacy callback blocks
- Store current URI/headers for proper source reload capability

## Testing

Tested in production with BRICKS app on both iOS and Android.