### PR TITLE
fix(ci): update Java to 17 and fix boost download URL

### DIFF
--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
 
       - name: Finalize Android SDK
         if: env.turbo_cache_hit != 1

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -61,6 +61,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cocoapods-
 
+      - name: Fix boost download URL
+        if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'
+        run: |
+          # The JFrog artifactory URL for boost is broken/redirecting incorrectly
+          # Use the official archives.boost.io mirror instead
+          BOOST_PODSPEC="example/node_modules/react-native/third-party-podspecs/boost.podspec"
+          if [ -f "$BOOST_PODSPEC" ]; then
+            sed -i '' 's|boostorg.jfrog.io/artifactory/main/release|archives.boost.io/release|g' "$BOOST_PODSPEC"
+          fi
+
       - name: Install cocoapods
         if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
## Problem

CI was failing due to:

1. **Android**: `sdkmanager` requires Java 17+ but CI was using Java 11

2. **iOS**: Boost download URL (`boostorg.jfrog.io`) is broken - returning redirect/error instead of tarball
   ```
   tar: Error opening archive: Unrecognized archive format
   ```

## Solution

1. **Android**: Update JDK from 11 to 17
2. **iOS**: Patch boost.podspec to use working `archives.boost.io` mirror before `pod install`

## Verification

```bash
# Old URL (broken):
curl -sI 'https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2'
# Returns: 302 redirect (incorrect content)

# New URL (works):
curl -sI 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2'
# Returns: 200 OK
```